### PR TITLE
check if Mix_HasMusicDecoder is available

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -30,6 +30,10 @@ if test "$PHP_SDL_MIXER" != "no"; then
       AC_MSG_ERROR([libSDL2_mixer not found!])
     ])
 
+    AC_CHECK_LIB(SDL2_mixer, Mix_HasMusicDecoder, [
+      AC_DEFINE(HAVE_MIX_HASMUSICDECODER, 1, [ Have sdl_mixer support ])
+    ])
+
   AC_DEFINE(HAVE_SDL_MIXER, 1, [ Have sdl_mixer support ])
 
   PHP_SUBST(SDL_MIXER_SHARED_LIBADD)

--- a/src/music.c
+++ b/src/music.c
@@ -83,6 +83,7 @@ PHP_FUNCTION(Mix_GetMusicDecoder)
 	RETURN_STRING(result);
 }
 
+#if defined(HAVE_MIX_HASMUSICDECODER)
 PHP_FUNCTION(Mix_HasMusicDecoder)
 {
 	char *name = NULL;
@@ -96,6 +97,7 @@ PHP_FUNCTION(Mix_HasMusicDecoder)
 
 	RETURN_BOOL(result == SDL_TRUE);
 }
+#endif
 
 PHP_FUNCTION(Mix_PlayMusic)
 {

--- a/src/php_sdl_mixer.stub.php
+++ b/src/php_sdl_mixer.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-function-entries
+ * @generate-class-entries
+ */
 
 function Mix_Init(int $flags): int {}
 function Mix_Quit(): void {}
@@ -42,7 +45,9 @@ function Mix_LoadMUS_RW(SDL_RWops $src, int $freesrc): Mix_Music {}
 function Mix_FreeMusic(Mix_Music $music): void {}
 function Mix_GetNumMusicDecoders(): int {}
 function Mix_GetMusicDecoder(int $index): string {}
+#ifdef HAVE_MIX_HASMUSICDECODER
 function Mix_HasMusicDecoder(string $name): bool {}
+#endif
 function Mix_PlayMusic(Mix_Music $music, int $loops): int {}
 function Mix_FadeInMusic(Mix_Music $music, int $loops, int $ms): int {}
 function Mix_FadeInMusicPos(Mix_Music $music, int $loops, int $ms, float $position): int {}

--- a/src/php_sdl_mixer_arginfo.h
+++ b/src/php_sdl_mixer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1a36e3ed90a9a7c0ff05a89516ad4bcec0ef0d44 */
+ * Stub hash: 0dec727e1d30954b0817f144d4e81e938a9f2d3c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Mix_Init, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
@@ -168,7 +168,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_Mix_GetMusicDecoder arginfo_Mix_GetChunkDecoder
 
-#define arginfo_Mix_HasMusicDecoder arginfo_Mix_HasChunkDecoder
+#if defined(HAVE_MIX_HASMUSICDECODER)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Mix_HasMusicDecoder, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Mix_PlayMusic, 0, 2, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, music, Mix_Music, 0)
@@ -292,7 +296,9 @@ ZEND_FUNCTION(Mix_LoadMUS_RW);
 ZEND_FUNCTION(Mix_FreeMusic);
 ZEND_FUNCTION(Mix_GetNumMusicDecoders);
 ZEND_FUNCTION(Mix_GetMusicDecoder);
+#if defined(HAVE_MIX_HASMUSICDECODER)
 ZEND_FUNCTION(Mix_HasMusicDecoder);
+#endif
 ZEND_FUNCTION(Mix_PlayMusic);
 ZEND_FUNCTION(Mix_FadeInMusic);
 ZEND_FUNCTION(Mix_FadeInMusicPos);
@@ -359,7 +365,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(Mix_FreeMusic, arginfo_Mix_FreeMusic)
 	ZEND_FE(Mix_GetNumMusicDecoders, arginfo_Mix_GetNumMusicDecoders)
 	ZEND_FE(Mix_GetMusicDecoder, arginfo_Mix_GetMusicDecoder)
+#if defined(HAVE_MIX_HASMUSICDECODER)
 	ZEND_FE(Mix_HasMusicDecoder, arginfo_Mix_HasMusicDecoder)
+#endif
 	ZEND_FE(Mix_PlayMusic, arginfo_Mix_PlayMusic)
 	ZEND_FE(Mix_FadeInMusic, arginfo_Mix_FadeInMusic)
 	ZEND_FE(Mix_FadeInMusicPos, arginfo_Mix_FadeInMusicPos)


### PR DESCRIPTION
Strangely, function is in SDL_mixer.h but not available in the library, so not usable

