### PR TITLE
split stub and arginfo and fix segfault

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -48,8 +48,12 @@
                 <file name="effect_stereoreverse.h" role="src" />
                 <file name="Mix_Chunk.c" role="src" />
                 <file name="Mix_Chunk.h" role="src" />
+                <file name="Mix_Chunk.stub.php" role="src" />
+                <file name="Mix_Chunk_arginfo.h" role="src" />
                 <file name="Mix_Music.c" role="src" />
                 <file name="Mix_Music.h" role="src" />
+                <file name="Mix_Music.stub.php" role="src" />
+                <file name="Mix_Music_arginfo.h" role="src" />
                 <file name="mixer.c" role="src" />
                 <file name="mixer.h" role="src" />
                 <file name="music.c" role="src" />

--- a/src/Mix_Chunk.c
+++ b/src/Mix_Chunk.c
@@ -1,4 +1,5 @@
 #include "Mix_Chunk.h"
+#include "Mix_Chunk_arginfo.h"
 
 zend_class_entry *mix_chunk_ce = NULL;
 zend_object_handlers php_mix_chunk_object_handlers;

--- a/src/Mix_Chunk.stub.php
+++ b/src/Mix_Chunk.stub.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @generate-class-entries
+ */
+
+final class Mix_Chunk {}
+

--- a/src/Mix_Chunk_arginfo.h
+++ b/src/Mix_Chunk_arginfo.h
@@ -1,0 +1,20 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 4d3739c322fe06235f1b4d21c5ad9a8b3bf45f02 */
+
+
+
+
+static const zend_function_entry class_Mix_Chunk_methods[] = {
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_Mix_Chunk(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "Mix_Chunk", class_Mix_Chunk_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	return class_entry;
+}

--- a/src/Mix_Music.c
+++ b/src/Mix_Music.c
@@ -1,4 +1,5 @@
 #include "Mix_Music.h"
+#include "Mix_Music_arginfo.h"
 
 zend_class_entry *mix_music_ce = NULL;
 zend_object_handlers php_mix_music_object_handlers;

--- a/src/Mix_Music.stub.php
+++ b/src/Mix_Music.stub.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @generate-class-entries
+ */
+
+final class Mix_Music {}
+

--- a/src/Mix_Music_arginfo.h
+++ b/src/Mix_Music_arginfo.h
@@ -1,0 +1,20 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: c6b5d170cc55f739aa2b0cb08eae7d8d2bb45404 */
+
+
+
+
+static const zend_function_entry class_Mix_Music_methods[] = {
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_Mix_Music(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "Mix_Music", class_Mix_Music_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	return class_entry;
+}

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -4,9 +4,6 @@
 
 #include "mixer.h"
 
-static zend_class_entry *php_mix_chunk_ce;
-static zend_object_handlers php_mix_chunk_handlers;
-
 extern zend_class_entry *mix_chunk_ce;
 extern zend_class_entry *get_php_sdl_rwops_ce(void);
 extern SDL_RWops *zval_to_sdl_rwops(zval *z_val);

--- a/src/php_sdl_mixer.c
+++ b/src/php_sdl_mixer.c
@@ -2,6 +2,7 @@
 #include "mixer.h"
 #include "music.h"
 #include "php_sdl_mixer_arginfo.h"
+#include "zend_smart_string.h"
 
 #ifdef COMPILE_DL_SDL_MIXER
 ZEND_GET_MODULE(sdl_mixer)
@@ -9,9 +10,13 @@ ZEND_GET_MODULE(sdl_mixer)
 
 #define PHP_MINIT_CALL(func) PHP_MINIT(func)(INIT_FUNC_ARGS_PASSTHRU)
 
+static int sld_mixer_flags;
+
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(sdl_mixer)
 {
+	sld_mixer_flags = Mix_Init(MIX_INIT_FLAC|MIX_INIT_MOD|MIX_INIT_MP3|MIX_INIT_OGG|MIX_INIT_MID|MIX_INIT_OPUS);
+
 	php_mix_chunk_minit_helper();
 	php_mix_music_minit_helper();
 
@@ -25,9 +30,19 @@ PHP_MINIT_FUNCTION(sdl_mixer)
 }
 /* }}} */
 
+/* {{{ PHP_MINIT_FUNCTION */
+PHP_MSHUTDOWN_FUNCTION(sdl_mixer)
+{
+	Mix_Quit();
+
+	return SUCCESS;
+}
+/* }}} */
+
 PHP_MINFO_FUNCTION(sdl_mixer)
 {
 	char buffer[128];
+	smart_string info = {0};
 	SDL_version compile_version;
 	const SDL_version *link_version = Mix_Linked_Version();
 	SDL_MIXER_VERSION(&compile_version);
@@ -39,6 +54,28 @@ PHP_MINFO_FUNCTION(sdl_mixer)
 	php_info_print_table_row(2, "SDL_mixer linked version", buffer);
 	snprintf(buffer, sizeof(buffer), "%d.%d.%d", compile_version.major, compile_version.minor, compile_version.patch);
 	php_info_print_table_row(2, "SDL_mixer compiled version", buffer);
+	if (sld_mixer_flags & MIX_INIT_FLAC) {
+		smart_string_appends(&info, "flac");
+	}
+	if (sld_mixer_flags & MIX_INIT_MOD) {
+		smart_string_appends(&info, ", mod");
+	}
+	if (sld_mixer_flags & MIX_INIT_MP3) {
+		smart_string_appends(&info, ", mp3");
+	}
+	if (sld_mixer_flags & MIX_INIT_OGG) {
+		smart_string_appends(&info, ", ogg");
+	}
+	if (sld_mixer_flags & MIX_INIT_MID) {
+		smart_string_appends(&info, ", mid");
+	}
+	if (sld_mixer_flags & MIX_INIT_OPUS) {
+		smart_string_appends(&info, ", opus");
+	}
+	smart_string_0(&info);
+	php_info_print_table_row(2, "SDL_mixer flags", info.c);
+	smart_string_free(&info);
+
 	php_info_print_table_end();
 }
 
@@ -54,7 +91,7 @@ zend_module_entry sdl_mixer_module_entry = {
 	"SDL_mixer",
 	ext_functions,
 	PHP_MINIT(sdl_mixer),
-	NULL, /* PHP_MSHUTDOWN - Module shutdown */
+	PHP_MSHUTDOWN(sdl_mixer),
 	NULL, /* PHP_RINIT - Request initialization */
 	NULL, /* PHP_RSHUTDOWN - Request shutdown */
 	PHP_MINFO(sdl_mixer),

--- a/src/php_sdl_mixer.c
+++ b/src/php_sdl_mixer.c
@@ -1,6 +1,7 @@
 #include "php_sdl_mixer.h"
 #include "mixer.h"
 #include "music.h"
+#include "php_sdl_mixer_arginfo.h"
 
 #ifdef COMPILE_DL_SDL_MIXER
 ZEND_GET_MODULE(sdl_mixer)

--- a/src/php_sdl_mixer.h
+++ b/src/php_sdl_mixer.h
@@ -23,7 +23,6 @@ extern "C" {
 #include <php.h>
 #include <ext/standard/info.h>
 #include "SDL_mixer.h"
-#include "php_sdl_mixer_arginfo.h"
 
 #ifdef  __cplusplus
 } // extern "C"

--- a/src/php_sdl_mixer.stub.php
+++ b/src/php_sdl_mixer.stub.php
@@ -76,5 +76,3 @@ function Mix_GetError(): string {}
 /** @alias SDL_ClearError */
 function Mix_ClearError(): string {}
 
-final class Mix_Chunk {}
-final class Mix_Music {}

--- a/src/php_sdl_mixer_arginfo.h
+++ b/src/php_sdl_mixer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0dec727e1d30954b0817f144d4e81e938a9f2d3c */
+ * Stub hash: 06f9569d612687e9fe0e904dcce9ebd88f9e6997 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Mix_Init, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
@@ -393,35 +393,3 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FALIAS(Mix_ClearError, SDL_ClearError, arginfo_Mix_ClearError)
 	ZEND_FE_END
 };
-
-
-static const zend_function_entry class_Mix_Chunk_methods[] = {
-	ZEND_FE_END
-};
-
-
-static const zend_function_entry class_Mix_Music_methods[] = {
-	ZEND_FE_END
-};
-
-static zend_class_entry *register_class_Mix_Chunk(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_CLASS_ENTRY(ce, "Mix_Chunk", class_Mix_Chunk_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-	class_entry->ce_flags |= ZEND_ACC_FINAL;
-
-	return class_entry;
-}
-
-static zend_class_entry *register_class_Mix_Music(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_CLASS_ENTRY(ce, "Mix_Music", class_Mix_Music_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-	class_entry->ce_flags |= ZEND_ACC_FINAL;
-
-	return class_entry;
-}


### PR DESCRIPTION
First commit: 

In current code, arginfo is included in all c file, and defined various static objects, so these are defined multiple times (and also raise build warning about "defined but not used")

With this split, each arginfo header is included only once in a single c file.

For now all PHP_FUNCTION are still defined in the main arginfo file, can be split, but perhaps don't worth it.